### PR TITLE
Port over code

### DIFF
--- a/.github/workflows/errors.js
+++ b/.github/workflows/errors.js
@@ -1,0 +1,6 @@
+// Function to handle Plotly loading errors
+// Can happen if version or CDN is not properly specified or otherwise unavailable
+function handlePlotlyError() {
+    console.error('Failed to load Plotly library.');
+    document.body.innerHTML = '<h1>Error: Plotly library could not be loaded.</h1>';
+}


### PR DESCRIPTION
From original source, which is now splitting the project between content and site

Future: make it an actual proper JS package rather than static site, so that `gh-pages` branch holds a bit more than just previews (but also builds)