### PR TITLE
Sync selected dandiset with URL query parameter

### DIFF
--- a/plots.js
+++ b/plots.js
@@ -183,23 +183,27 @@ fetch(ALL_DANDISET_TOTALS_URL)
             selector.appendChild(option);
         });
 
-        // Check URL for a dandiset parameter, default to "archive"
-        const urlParams = new URLSearchParams(window.location.search);
-        const urlDandiset = urlParams.get("dandiset");
-        const initialDandiset = urlDandiset && dandiset_ids.includes(urlDandiset) ? urlDandiset : "archive";
-        selector.value = initialDandiset;
+        // Normalize a raw dandiset ID to a valid selection, falling back to "archive"
+        const validateDandisetId = (raw) => (raw && dandiset_ids.includes(raw) ? raw : "archive");
 
-        // Load the plots for the initial selection
-        update_totals(initialDandiset);
-        load_over_time_plot(initialDandiset);
-        load_histogram(initialDandiset);
-        load_aws_histogram(initialDandiset);
-        load_geographic_heatmap(initialDandiset);
+        // Update the selector and reload all plots/totals for the given dandiset ID
+        const setSelectedDandiset = (rawId) => {
+            const id = validateDandisetId(rawId);
+            selector.value = id;
+            update_totals(id);
+            load_over_time_plot(id);
+            load_histogram(id);
+            load_aws_histogram(id);
+            load_geographic_heatmap(id);
+        };
+
+        // Check URL for a dandiset parameter and load initial plots
+        const urlParams = new URLSearchParams(window.location.search);
+        setSelectedDandiset(urlParams.get("dandiset"));
 
         // Update the plots and URL when a new Dandiset ID is selected
         selector.addEventListener("change", (event) => {
-            const target = event.target;
-            const id = target.value;
+            const id = event.target.value;
             const params = new URLSearchParams(window.location.search);
             if (id === "archive") {
                 params.delete("dandiset");
@@ -209,25 +213,13 @@ fetch(ALL_DANDISET_TOTALS_URL)
             const query = params.toString();
             const newUrl = window.location.pathname + (query ? "?" + query : "");
             window.history.pushState({}, "", newUrl);
-            update_totals(id);
-            load_over_time_plot(id);
-            load_histogram(id);
-            load_aws_histogram(id);
-            load_geographic_heatmap(id);
+            setSelectedDandiset(id);
         });
 
         // Handle browser back/forward navigation
         window.addEventListener("popstate", () => {
             const params = new URLSearchParams(window.location.search);
-            const id = params.get("dandiset") || "archive";
-            if (dandiset_ids.includes(id)) {
-                selector.value = id;
-                update_totals(id);
-                load_over_time_plot(id);
-                load_histogram(id);
-                load_aws_histogram(id);
-                load_geographic_heatmap(id);
-            }
+            setSelectedDandiset(params.get("dandiset"));
         });
     })
     .catch((error) => {


### PR DESCRIPTION
## Summary
- Reads `?dandiset=<ID>` from the URL on page load to pre-select a dandiset
- Updates the URL when the user changes the dropdown selection
- Supports browser back/forward navigation between selections
- Defaults to "archive" when no parameter is present or the ID is invalid

## Test plan
- [ ] Load page without query param — should default to "archive"
- [ ] Load page with `?dandiset=000003` — should select that dandiset and show its plots
- [ ] Load page with invalid `?dandiset=999999` — should fall back to "archive"
- [ ] Change dropdown selection — URL should update without page reload
- [ ] Use browser back/forward — should navigate between previous selections

🤖 Generated with [Claude Code](https://claude.com/claude-code)