### PR TITLE
Use case-sensitive name to avoid warning?

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,7 +3,7 @@ updates:
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "quarterly"
     reviewers:
       - "CodyCBakerPhD"
     assignees:
@@ -12,7 +12,7 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "quarterly"
     reviewers:
       - "CodyCBakerPhD"
     assignees:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,15 +5,15 @@ updates:
     schedule:
       interval: "daily"
     reviewers:
-      - "codycbakerphd"
+      - "CodyCBakerPhD"
     assignees:
-      - "codycbakerphd"
+      - "CodyCBakerPhD"
 
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "daily"
     reviewers:
-      - "codycbakerphd"
+      - "CodyCBakerPhD"
     assignees:
-      - "codycbakerphd"
+      - "CodyCBakerPhD"


### PR DESCRIPTION
Updated reviewer and assignee usernames to match case.

Just trying to see if this works