### PR TITLE
Add MIT license and REUSE compliance configuration

### DIFF
--- a/.github/workflows/chromatic-playwright.yml
+++ b/.github/workflows/chromatic-playwright.yml
@@ -33,3 +33,4 @@ jobs:
               with:
                   projectToken: ${{ secrets.CHROMATIC_PLAYWRIGHT_PROJECT_TOKEN }}
                   playwright: true
+                  autoAcceptChanges: main

--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -23,3 +23,4 @@ jobs:
               uses: chromaui/action@latest
               with:
                   projectToken: ${{ secrets.CHROMATIC_STORYBOOK_PROJECT_TOKEN }}
+                  autoAcceptChanges: main

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,6 +21,11 @@ repos:
     - tomli
     exclude: '(gadm_admin1_simplified\.topojson|name_aliases\.json|package-lock\.json)$'
 
+- repo: https://github.com/fsfe/reuse-tool
+  rev: v6.2.0
+  hooks:
+  - id: reuse
+
 - repo: https://github.com/compilerla/conventional-pre-commit
   rev: v4.4.0
   hooks:

--- a/.reuse/dep5
+++ b/.reuse/dep5
@@ -1,8 +1,0 @@
-Format: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
-Upstream-Name: usage-page
-Upstream-Contact: DANDI <info@dandiarchive.org>
-Source: https://github.com/dandi/usage-page
-
-Files: *
-Copyright: 2024 DANDI contributors
-License: MIT

--- a/.reuse/dep5
+++ b/.reuse/dep5
@@ -1,0 +1,8 @@
+Format: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
+Upstream-Name: usage-page
+Upstream-Contact: DANDI <info@dandiarchive.org>
+Source: https://github.com/dandi/usage-page
+
+Files: *
+Copyright: 2024 DANDI contributors
+License: MIT

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,1 @@
+LICENSES/MIT.txt

--- a/LICENSES/MIT.txt
+++ b/LICENSES/MIT.txt
@@ -1,0 +1,18 @@
+MIT License
+
+Copyright (c) <year> <copyright holders>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+associated documentation files (the "Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the
+following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial
+portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT
+LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO
+EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/REUSE.toml
+++ b/REUSE.toml
@@ -1,0 +1,7 @@
+version = 1
+
+[[annotations]]
+path = "**"
+precedence = "aggregate"
+SPDX-FileCopyrightText = "2024 DANDI contributors <info@dandiarchive.org>"
+SPDX-License-Identifier = "MIT"


### PR DESCRIPTION
## Summary
This PR adds proper licensing and REUSE compliance tooling to the project, along with minor CI/CD improvements for Chromatic integration.

## Key Changes
- **License**: Added MIT license file (`LICENSES/MIT.txt`) with standard MIT license text
- **REUSE Compliance**: Added `.reuse/dep5` configuration file to declare copyright and licensing information in REUSE-compliant format
- **Pre-commit Hook**: Integrated REUSE tool (v6.2.0) as a pre-commit hook to ensure license compliance on every commit
- **Chromatic CI/CD**: Enabled `autoAcceptChanges: main` in both Chromatic workflows (Storybook and Playwright) to automatically accept baseline changes on the main branch

## Implementation Details
- The `.reuse/dep5` file declares the project as "usage-page" maintained by DANDI contributors under MIT license
- REUSE tool integration will validate that all files have proper copyright and license information
- Chromatic auto-accept configuration streamlines the visual regression testing workflow by automatically accepting changes merged to main

https://claude.ai/code/session_01XE3toCSsfYnpVQfD7Hrh5z