### PR TITLE
Add footnotes clarifying visitor counting and data attribution

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "access-page",
-  "version": "1.5.2",
+  "version": "1.5.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "access-page",
-      "version": "1.5.2",
+      "version": "1.5.3",
       "license": "MIT",
       "dependencies": {
         "js-yaml": "^4.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "access-page",
-  "version": "1.5.2",
+  "version": "1.5.3",
   "description": "Visualizations of data usage across the archive.",
   "private": true,
   "type": "module",

--- a/src/plots.ts
+++ b/src/plots.ts
@@ -905,7 +905,7 @@ function update_totals(dandiset_id: string) {
         const header =
             `A total of ${human_readable_bytes_sent} was transferred in ` +
             `${web_requests} web requests and ${downloads} full downloads ` +
-            `by ${visitors} unique visitors across ${regions} regions in ` +
+            `by ${visitors} unique visitors<sup>&dagger;</sup> across ${regions} regions in ` +
             `${countries} countries. <sup>*</sup>`;
         totals_element!.innerHTML = dandiset_id === "undetermined"
                 ? header + `<br>However, the usage could not be uniquely associated with a particular Dandiset.<br>The primary cause of this is when an asset is removed from a 'draft' state prior to being made persistent by publication.`
@@ -915,7 +915,8 @@ function update_totals(dandiset_id: string) {
         const footnote = document.createElement("div");
         footnote.style.fontSize = "0.5em";
         footnote.style.marginTop = "7px";
-        footnote.innerHTML = "<sup>*</sup> Dandiset source determination is heuristic and may change over time.<br>Activity that cannot be confidently attributed to a Dandiset or any other field is reported as 'undetermined'.";
+        footnote.innerHTML = "<sup>*</sup> Dandiset source determination is heuristic and may change over time.<br>Activity that cannot be confidently attributed to a Dandiset or any other field is reported as 'undetermined'." +
+            "<br><sup>&dagger;</sup> Unique visitors are counted by unique IP address and may be skewed by undetermined VPN usage patterns.";
         totals_element!.appendChild(footnote);
     } catch (error) {
         console.error("Error:", error);


### PR DESCRIPTION
## Summary
Added clarifying footnotes to the usage statistics header to provide users with important context about how unique visitors are counted and how Dandiset source determination works.

## Key Changes
- Added a dagger symbol (`<sup>&dagger;</sup>`) next to "unique visitors" in the totals header to reference a new footnote
- Added a new footnote explaining that unique visitors are counted by IP address and may be affected by VPN usage patterns
- Reorganized the footnote text to include both the existing asterisk note about Dandiset source determination and the new dagger note about visitor counting methodology

## Implementation Details
- The footnote HTML is now constructed by concatenating two explanatory statements
- Both footnotes are displayed in the same small-text footer element (0.5em font size with 7px top margin)
- The changes maintain the existing styling and layout of the statistics display

https://claude.ai/code/session_01GtAPTPk6UvFi83whnfiW8T