### PR TITLE
Add human-readable titles to Dandiset ID displays

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 #### 🚀 Enhancement
 
+- Annotated Dandiset ID displays with their current title fetched from an external Dandiset-ID-to-title cache: the Dandiset selector dropdown, the "Usage per Dandiset" histogram's hover text and grouped over-time plot hover text now show "ID - Title", and the histogram table gained a new "Name" column. Falls back to the bare ID when a title is unavailable. ([#236](https://github.com/dandi/usage-page/pull/236))
 - Added pointers to the underlying source data ([dandi/access-summaries](https://github.com/dandi/access-summaries)): a data-repository icon in the header beside the existing code icon, a per-Dandiset link beside the selector to the GitHub folder of summary tables for the current selection, a "Data ▾" menu on every table view (GitHub file view · raw download · containing folder) replacing the previous raw-CDN "Data" link, and a "View source data on GitHub" modebar button on every plot. ([#234](https://github.com/dandi/usage-page/pull/234))
 
 - Excluded the 'undetermined' Dandiset ID from the usage-per-dandiset histogram plot while keeping it visible in the table view. ([#191](https://github.com/dandi/usage-page/pull/191))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 #### 🚀 Enhancement
 
-- Annotated Dandiset ID displays with their current title fetched from an external Dandiset-ID-to-title cache: the Dandiset selector dropdown, the "Usage per Dandiset" histogram's hover text and grouped over-time plot hover text now show "ID - Title", and the histogram table gained a new "Name" column. Falls back to the bare ID when a title is unavailable. ([#236](https://github.com/dandi/usage-page/pull/236))
+- Annotated Dandiset ID displays with their current title fetched from an external Dandiset-ID-to-title cache: the Dandiset selector dropdown, the "Usage per Dandiset" histogram's hover text and grouped over-time plot hover text now show "ID - Title", and the histogram table gained a new "Name" column. The "archive" (whole-archive) selection is always labeled "(All) - Archive". Falls back to the bare ID when a title is unavailable. ([#236](https://github.com/dandi/usage-page/pull/236))
 - Added pointers to the underlying source data ([dandi/access-summaries](https://github.com/dandi/access-summaries)): a data-repository icon in the header beside the existing code icon, a per-Dandiset link beside the selector to the GitHub folder of summary tables for the current selection, a "Data ▾" menu on every table view (GitHub file view · raw download · containing folder) replacing the previous raw-CDN "Data" link, and a "View source data on GitHub" modebar button on every plot. ([#234](https://github.com/dandi/usage-page/pull/234))
 
 - Excluded the 'undetermined' Dandiset ID from the usage-per-dandiset histogram plot while keeping it visible in the table view. ([#191](https://github.com/dandi/usage-page/pull/191))

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "access-page",
-  "version": "1.6.1",
+  "version": "1.7.0",
   "description": "Visualizations of data usage across the archive.",
   "private": true,
   "type": "module",

--- a/src/plot-helpers.ts
+++ b/src/plot-helpers.ts
@@ -108,10 +108,13 @@ export function parse_dandiset_titles_jsonl(text: string): Record<string, string
 
 /**
  * Formats a Dandiset ID for display, appending " - <title>" when a title is
- * known. Falls back to the bare ID (e.g. "archive", "undetermined", or any
- * ID missing from the lookup) when no title is available.
+ * known. The "archive" sentinel ID (the whole-archive selection) is always
+ * rendered as "(All) - Archive" instead of being looked up. Falls back to
+ * the bare ID (e.g. "undetermined", or any ID missing from the lookup) when
+ * no title is available.
  */
 export function format_dandiset_label(id: string, titles: Record<string, string>): string {
+    if (id === "archive") return "(All) - Archive";
     const title = titles[id];
     return title ? `${id} - ${title}` : id;
 }

--- a/src/plot-helpers.ts
+++ b/src/plot-helpers.ts
@@ -84,6 +84,38 @@ export async function fetchWithRetry(url: string, options: RequestInit = {}, max
     throw new Error("fetchWithRetry: exhausted retries");
 }
 
+// ── Dandiset ID → title mapping ────────────────────────────────────────────
+
+/**
+ * Parses a newline-delimited JSON (JSONL) file where each line is a single
+ * `{ "<dandiset_id>": "<title>" }` object, merging them into one lookup map.
+ * Blank lines and lines that fail to parse are skipped so a single malformed
+ * entry doesn't prevent the rest of the file from loading.
+ */
+export function parse_dandiset_titles_jsonl(text: string): Record<string, string> {
+    const titles: Record<string, string> = {};
+    text.split("\n").forEach((line) => {
+        const trimmed = line.trim();
+        if (!trimmed) return;
+        try {
+            Object.assign(titles, JSON.parse(trimmed));
+        } catch {
+            // Skip malformed lines rather than failing the whole page.
+        }
+    });
+    return titles;
+}
+
+/**
+ * Formats a Dandiset ID for display, appending " - <title>" when a title is
+ * known. Falls back to the bare ID (e.g. "archive", "undetermined", or any
+ * ID missing from the lookup) when no title is available.
+ */
+export function format_dandiset_label(id: string, titles: Record<string, string>): string {
+    const title = titles[id];
+    return title ? `${id} - ${title}` : id;
+}
+
 // ── View-mode helpers ─────────────────────────────────────────────────────────
 
 /**

--- a/src/plots.ts
+++ b/src/plots.ts
@@ -15,6 +15,8 @@ import {
     apply_geo_view_mode,
     derive_data_source_urls,
     render_sortable_table,
+    parse_dandiset_titles_jsonl,
+    format_dandiset_label,
 } from "./plot-helpers.js";
 import { load as loadYaml } from "js-yaml";
 import Plotly from "plotly.js-dist-min";
@@ -335,6 +337,8 @@ const BASE_TSV_URL = `${BASE_URL}/content/summaries`;
 const ARCHIVE_TOTALS_URL = `${BASE_URL}/content/archive_totals.json`;
 const ALL_DANDISET_TOTALS_URL = `${BASE_URL}/content/totals.json`;
 const REGION_CODES_TO_LATITUDE_LONGITUDE_URL = `${BASE_URL}/content/region_codes_to_coordinates.yaml`;
+const DANDISET_ID_TO_TITLE_URL =
+    "https://raw.githubusercontent.com/dandi-cache/dandiset-id-to-title/derivatives/derivatives/dandiset_id_to_title.jsonl";
 
 interface DandisetTotals {
     total_bytes_sent: number;
@@ -347,6 +351,8 @@ interface DandisetTotals {
 
 let REGION_CODES_TO_LATITUDE_LONGITUDE: Record<string, { latitude: number; longitude: number }> = {};
 let ALL_DANDISET_TOTALS: Record<string, DandisetTotals> = {};
+// Maps a Dandiset ID to its current title, used to annotate ID displays with a human-readable name.
+let DANDISET_TITLES: Record<string, string> = {};
 let USE_LOG_SCALE = false;
 let USE_CUMULATIVE = false;
 let USE_OT_LINE_PLOT = false;
@@ -817,8 +823,19 @@ const allDandisetTotalsPromise = fetchWithRetry(ALL_DANDISET_TOTALS_URL)
         throw error; // Propagate so Promise.all rejects and its .catch() renders the error message
     });
 
+// Dandiset titles are cosmetic (ID displays fall back to the bare ID when
+// missing), so a failure here is logged but does not block the rest of the page.
+const dandisetTitlesPromise = fetchWithRetry(DANDISET_ID_TO_TITLE_URL)
+    .then((response) => response.text())
+    .then((dandiset_titles_text) => {
+        Object.assign(DANDISET_TITLES, parse_dandiset_titles_jsonl(dandiset_titles_text));
+    })
+    .catch((error) => {
+        console.error("Error loading dandiset titles:", error);
+    });
+
 // Populate the dropdown with IDs and render initial plots only after both fetches complete
-Promise.all([archiveTotalsPromise, allDandisetTotalsPromise])
+Promise.all([archiveTotalsPromise, allDandisetTotalsPromise, dandisetTitlesPromise])
     .then(() => {
         // Re-sync from URL here as a safety net: if DOMContentLoaded fired
         // before the data was ready, the global state is already correct, but
@@ -850,7 +867,7 @@ Promise.all([archiveTotalsPromise, allDandisetTotalsPromise])
         dandiset_ids.forEach((id) => {
             const option = document.createElement("option");
             option.value = id;
-            option.textContent = id;
+            option.textContent = format_dandiset_label(id, DANDISET_TITLES);
             selector.appendChild(option);
         });
 
@@ -1373,7 +1390,7 @@ function load_over_time_plot(dandiset_id: string): Promise<void> {
                         x: global_bins,
                         y: plot_data,
                         text: global_bins.map((date, idx) =>
-                            `DANDI:${series.id}<br>${bin_label_prefix[TIME_AGGREGATION]}${date}<br>${human_readable[idx]}` +
+                            `DANDI:${format_dandiset_label(series.id, DANDISET_TITLES)}<br>${bin_label_prefix[TIME_AGGREGATION]}${date}<br>${human_readable[idx]}` +
                             hover_metric("Requests", display_req[idx]) +
                             hover_metric("Downloads", display_dl[idx])
                         ),
@@ -1652,13 +1669,17 @@ function load_dandiset_histogram(): Promise<void> {
     .then((data) => {
         // Exclude 'archive' and cast IDs to strings; sort by bytes descending
         const combined = Object.keys(data)
-            .map(dandiset_id => ({
-                raw_id: String(dandiset_id),
-                dandiset_id: "Dandiset ID " + String(dandiset_id),
-                bytes: data[dandiset_id].total_bytes_sent,
-                requests: data[dandiset_id].total_number_of_requests as number,
-                downloads: data[dandiset_id].total_number_of_downloads as number,
-            }))
+            .map(dandiset_id => {
+                const raw_id = String(dandiset_id);
+                return {
+                    raw_id,
+                    dandiset_id: format_dandiset_label(raw_id, DANDISET_TITLES),
+                    title: DANDISET_TITLES[raw_id] ?? "",
+                    bytes: data[dandiset_id].total_bytes_sent,
+                    requests: data[dandiset_id].total_number_of_requests as number,
+                    downloads: data[dandiset_id].total_number_of_downloads as number,
+                };
+            })
             .sort((a, b) => b.bytes - a.bytes);
 
         // Exclude 'undetermined' from the plot only (table retains all entries)
@@ -1716,6 +1737,7 @@ function load_dandiset_histogram(): Promise<void> {
         const count_format = (n: number) => n.toLocaleString();
         render_sortable_table("histogram_table", "", [
             { label: "Dandiset ID", key: "raw_id", numeric: false },
+            { label: "Name", key: "title", numeric: false },
             { label: "Usage", key: "bytes", numeric: true },
             { label: "Requests", key: "requests", numeric: true, format_fn: count_format },
             { label: "Downloads", key: "downloads", numeric: true, format_fn: count_format },

--- a/tests/unit/plot-helpers.test.ts
+++ b/tests/unit/plot-helpers.test.ts
@@ -7,6 +7,8 @@ import {
     apply_geo_view_mode,
     derive_data_source_urls,
     render_sortable_table,
+    parse_dandiset_titles_jsonl,
+    format_dandiset_label,
 } from "../../src/plot-helpers.js";
 
 // ── escape_html ───────────────────────────────────────────────────────────────
@@ -444,6 +446,60 @@ describe("render_sortable_table", () => {
         expect((cells[1] as HTMLElement).textContent).toBe("1000000B");
         // count cell uses per-column formatter
         expect((cells[2] as HTMLElement).textContent).toBe("42,000");
+    });
+});
+
+// ── parse_dandiset_titles_jsonl ────────────────────────────────────────────────
+
+describe("parse_dandiset_titles_jsonl", () => {
+    it("parses one title per line into a single lookup map", () => {
+        const text = '{"000003": "Alpha dataset"}\n{"000004": "Beta dataset"}';
+        expect(parse_dandiset_titles_jsonl(text)).toEqual({
+            "000003": "Alpha dataset",
+            "000004": "Beta dataset",
+        });
+    });
+
+    it("skips blank lines", () => {
+        const text = '{"000003": "Alpha dataset"}\n\n\n{"000004": "Beta dataset"}\n';
+        expect(parse_dandiset_titles_jsonl(text)).toEqual({
+            "000003": "Alpha dataset",
+            "000004": "Beta dataset",
+        });
+    });
+
+    it("skips malformed lines without throwing", () => {
+        const text = '{"000003": "Alpha dataset"}\nnot json\n{"000004": "Beta dataset"}';
+        expect(parse_dandiset_titles_jsonl(text)).toEqual({
+            "000003": "Alpha dataset",
+            "000004": "Beta dataset",
+        });
+    });
+
+    it("returns an empty object for empty input", () => {
+        expect(parse_dandiset_titles_jsonl("")).toEqual({});
+    });
+});
+
+// ── format_dandiset_label ──────────────────────────────────────────────────────
+
+describe("format_dandiset_label", () => {
+    it("appends the title with a dash when known", () => {
+        expect(format_dandiset_label("000003", { "000003": "Alpha dataset" })).toBe(
+            "000003 - Alpha dataset"
+        );
+    });
+
+    it("falls back to the bare ID when the title is unknown", () => {
+        expect(format_dandiset_label("999999", { "000003": "Alpha dataset" })).toBe("999999");
+    });
+
+    it("falls back to the bare ID for special selections like 'archive'", () => {
+        expect(format_dandiset_label("archive", {})).toBe("archive");
+    });
+
+    it("falls back to the bare ID when the titles map is empty", () => {
+        expect(format_dandiset_label("000003", {})).toBe("000003");
     });
 });
 

--- a/tests/unit/plot-helpers.test.ts
+++ b/tests/unit/plot-helpers.test.ts
@@ -494,8 +494,12 @@ describe("format_dandiset_label", () => {
         expect(format_dandiset_label("999999", { "000003": "Alpha dataset" })).toBe("999999");
     });
 
-    it("falls back to the bare ID for special selections like 'archive'", () => {
-        expect(format_dandiset_label("archive", {})).toBe("archive");
+    it("renders the 'archive' sentinel ID as '(All) - Archive' instead of looking it up", () => {
+        expect(format_dandiset_label("archive", {})).toBe("(All) - Archive");
+    });
+
+    it("renders 'archive' as '(All) - Archive' even if a title happens to be registered for it", () => {
+        expect(format_dandiset_label("archive", { archive: "Should be ignored" })).toBe("(All) - Archive");
     });
 
     it("falls back to the bare ID when the titles map is empty", () => {


### PR DESCRIPTION
## Summary
This PR enhances the user experience by displaying human-readable Dandiset titles alongside their numeric IDs throughout the application. Dandiset titles are fetched from an external JSONL source and used to annotate ID displays in dropdowns, plots, and tables.

## Key Changes
- **New helper functions in `plot-helpers.ts`**:
  - `parse_dandiset_titles_jsonl()`: Parses newline-delimited JSON to extract Dandiset ID → title mappings, gracefully skipping blank lines and malformed entries
  - `format_dandiset_label()`: Formats a Dandiset ID for display, appending the title when available (e.g., "000003 - Alpha dataset") or falling back to the bare ID

- **Data loading in `plots.ts`**:
  - Added `DANDISET_ID_TO_TITLE_URL` constant pointing to an external GitHub-hosted JSONL file
  - Added `DANDISET_TITLES` global state to cache the fetched titles
  - Integrated `dandisetTitlesPromise` into the initialization flow; failures are logged but don't block page rendering (cosmetic feature)

- **UI updates in `plots.ts`**:
  - Dandiset selector dropdown now displays formatted labels with titles
  - Over-time plot hover text includes formatted Dandiset labels
  - Dandiset histogram table now includes a "Name" column showing titles
  - Histogram data structure extended with a `title` field for table rendering

## Implementation Details
- Titles are treated as cosmetic enhancements; missing or failed title loads gracefully fall back to bare IDs
- The JSONL parser is defensive—malformed lines are skipped rather than causing the entire page to fail
- The external title source is fetched in parallel with other data, minimizing performance impact
- All existing functionality remains unchanged when titles are unavailable

https://claude.ai/code/session_01BBYU5n3wabJBUG7x11nMsK