### PR TITLE
Restyled the scroll bars of the table views

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 #### 🚀 Enhancement
 
+- Restyled the scroll bars of every table view as a slim, rounded, accent-tinted thumb on a transparent track, replacing the platform default that read as a light gray slab against the table, most jarringly in dark mode. ([#245](https://github.com/dandi/usage-page/pull/245))
 - Added a "Metric" dropdown to the over-time and per-Dandiset histogram plots, so the plot is drawn in the chosen metric rather than always in bytes; the histogram additionally offers the scaled metrics for the archive-wide selection. Each choice is remembered in the URL (`ot_metric`, `hist_metric`), is shown only in plot view, and drives the plot's title and y-axis. ([#243](https://github.com/dandi/usage-page/pull/243))
 - Disabled the over-time metric dropdown while grouping by asset type, the one grouping whose source data carries no metric other than bytes. ([#243](https://github.com/dandi/usage-page/pull/243))
 - Ranked the bars of both histograms by the metric being plotted instead of always by bytes, and left out Dandisets with no value for the selected scaled metric. ([#243](https://github.com/dandi/usage-page/pull/243))

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "access-page",
-  "version": "1.10.6",
+  "version": "1.10.7",
   "description": "Visualizations of data usage across the archive.",
   "private": true,
   "type": "module",

--- a/src/styles.css
+++ b/src/styles.css
@@ -10,6 +10,8 @@
     --color-accent-rgb: 83, 168, 182;
     --color-accent-hover: #79c7d4;
     --color-accent-subtle: rgba(var(--color-accent-rgb), 0.08);
+    --color-scrollbar-thumb: rgba(var(--color-accent-rgb), 0.35);
+    --color-scrollbar-thumb-hover: rgba(var(--color-accent-rgb), 0.65);
     /* ─────────────────────────────────────────────────────────────────────── */
     --font-main: 'Source Sans 3', -apple-system, sans-serif;
     --radius: 6px;
@@ -27,6 +29,8 @@
     --color-accent-rgb: 83, 168, 182;
     --color-accent-hover: #3d8a97;
     --color-accent-subtle: rgba(var(--color-accent-rgb), 0.1);
+    --color-scrollbar-thumb: rgba(var(--color-accent-rgb), 0.45);
+    --color-scrollbar-thumb-hover: rgba(var(--color-accent-rgb), 0.75);
 }
 
 *, *::before, *::after {
@@ -439,6 +443,53 @@ input[type="number"]:focus {
     max-height: 480px;
     overflow-y: auto;
     overflow-x: auto;
+}
+
+/* ── Table scroll bars ──
+   The platform default is a wide light-gray slab with stepper arrows at both
+   ends, which reads as a foreign element pasted onto a themed table — most
+   glaringly in dark mode.  It is replaced with a slim, rounded, accent-tinted
+   thumb on a transparent track, so the table's own background runs all the way
+   to its edge and the thumb reads as part of the table.
+
+   The ::-webkit-scrollbar rules are used wherever they are understood (Chrome,
+   Safari), since they can also drop the stepper arrows; browsers without them
+   (Firefox) get the standard `scrollbar-*` properties instead.  Both paths are
+   needed because Chrome ignores the pseudo-elements as soon as the standard
+   properties are set, and Firefox supports only the standard ones. */
+@supports not selector(::-webkit-scrollbar) {
+    .plot-table-container {
+        scrollbar-width: thin;
+        scrollbar-color: var(--color-scrollbar-thumb) transparent;
+    }
+}
+
+.plot-table-container::-webkit-scrollbar {
+    width: 10px;
+    height: 10px;
+}
+
+.plot-table-container::-webkit-scrollbar-track,
+.plot-table-container::-webkit-scrollbar-corner {
+    background: transparent;
+}
+
+/* The transparent border, together with the padding-box clip, insets the thumb
+   from the edges of its track without a second element to color. */
+.plot-table-container::-webkit-scrollbar-thumb {
+    background-color: var(--color-scrollbar-thumb);
+    background-clip: padding-box;
+    border: 2px solid transparent;
+    border-radius: 999px;
+}
+
+.plot-table-container::-webkit-scrollbar-thumb:hover {
+    background-color: var(--color-scrollbar-thumb-hover);
+}
+
+/* Drops the stepper arrows at the ends of the track. */
+.plot-table-container::-webkit-scrollbar-button {
+    display: none;
 }
 
 .plot-table table {


### PR DESCRIPTION
Every table view scrolls inside `.plot-table-container`, which had `overflow: auto` and no scroll bar styling of its own, so it drew the platform default: a wide light-gray slab with stepper arrows at both ends. Against the dark navy of a table that reads as a bright white stripe down its right edge; in light theme it is a chunky gray bar. This replaces it with a slim, rounded, accent-tinted thumb on a transparent track, so the table's own background runs to its edge.

### Changes

- Added `--color-scrollbar-thumb` and `--color-scrollbar-thumb-hover` to the theme variables, tinted from the existing accent. The light theme uses slightly stronger alphas, since a translucent thumb washes out over white.
- Styled the thumb as a 10 px rounded bar, inset from its track by a transparent border plus `background-clip: padding-box` (which avoids needing a second colored element), on a transparent track and corner, with a hover state and no stepper arrows.

The rules are written twice, deliberately. The `::-webkit-scrollbar` pseudo-elements are used wherever they are understood (Chrome, Safari) because only they can drop the stepper arrows, and the standard `scrollbar-width` / `scrollbar-color` properties are gated behind `@supports not selector(::-webkit-scrollbar)` for Firefox. The two cannot both be applied: Chrome ignores the pseudo-elements as soon as the standard properties are set, and Firefox supports only the standard ones. A browser with neither simply keeps its default scroll bar.

All four table views (over-time, per-Dandiset, per-region, AWS) share the container class, so all four are covered.

### Verification

Checked by driving the page in headless Chromium against mocked data, in both themes, with Playwright's default `--hide-scrollbars` disabled so the bars actually render. `npm test` (217 passing), `npm run typecheck`, `npm run build`, and `pre-commit` over the changed files all pass.

`npm run format:check` still fails, but it already does on `main` for 19 files including `src/styles.css`; prettier is not part of the pre-commit config, so the new rules follow the surrounding style rather than reformatting the file.

---
_Generated by [Claude Code](https://claude.ai/code/session_015ruiYyMusq2AevGJf1kpVw)_