### PR TITLE
Removed "DANDI:" prefix from over-time plot hover text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 #### 🚀 Enhancement
 
+- Dropped the "DANDI:" prefix from the hover text of the over-time plot grouped by Dandisets, so each hover leads with the Dandiset's ID and title. ([#247](https://github.com/dandi/usage-page/pull/247))
 - Replaced the totals sentence and its block of footnotes above the plots with a table of the same metrics, each caveat behind an info icon on the metric (or the caption) it qualifies. The metrics are read as a row of labelled columns that wraps over as many lines as a narrow viewport needs, so the summary is never scrolled sideways. ([#246](https://github.com/dandi/usage-page/pull/246))
 - Restyled the scroll bars of every table view as a slim, rounded, accent-tinted thumb on a transparent track, replacing the platform default that read as a light gray slab against the table, most jarringly in dark mode. ([#245](https://github.com/dandi/usage-page/pull/245))
 - Added a "Metric" dropdown to the over-time and per-Dandiset histogram plots, so the plot is drawn in the chosen metric rather than always in bytes; the histogram additionally offers the scaled metrics for the archive-wide selection. Each choice is remembered in the URL (`ot_metric`, `hist_metric`), is shown only in plot view, and drives the plot's title and y-axis. ([#243](https://github.com/dandi/usage-page/pull/243))

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "access-page",
-  "version": "1.11.3",
+  "version": "1.11.4",
   "description": "Visualizations of data usage across the archive.",
   "private": true,
   "type": "module",

--- a/src/plots.ts
+++ b/src/plots.ts
@@ -1722,7 +1722,7 @@ function load_over_time_plot(dandiset_id: string): Promise<void> {
                         x: global_bins,
                         y: plot_data,
                         text: global_bins.map((date, idx) =>
-                            `DANDI:${format_dandiset_label(series.id, DANDISET_TITLES)}<br>${bin_label_prefix[TIME_AGGREGATION]}${date}` +
+                            `${format_dandiset_label(series.id, DANDISET_TITLES)}<br>${bin_label_prefix[TIME_AGGREGATION]}${date}` +
                             hover_metric_lines(OVER_TIME_METRIC, {
                                 bytes: display_metrics.bytes[idx],
                                 views: display_metrics.views[idx],


### PR DESCRIPTION
## Summary
Simplified the hover text labels in the over-time plot grouped by Dandisets by removing the redundant "DANDI:" prefix, allowing the Dandiset ID and title to lead directly.

## Changes
- Removed the `DANDI:` string prefix from the hover text template in the over-time plot, so hover labels now begin with the formatted Dandiset label (ID and title) rather than "DANDI:{ID} {title}"
- Updated version to 1.11.4
- Added changelog entry documenting the improvement

## Details
The change affects the hover tooltip text displayed when users interact with the over-time plot. Previously, hovering over a data point would show "DANDI:{dandiset_id} {title}", but now it shows just "{dandiset_id} {title}", making the interface cleaner while maintaining all necessary information.

https://claude.ai/code/session_019ru42mzWdZGDZmmvdv1Qui