### PR TITLE
Fixed undetermined file types calculation in asset-type plot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 #### 🐛 Bug Fix
 
-- Fixed the "Undetermined file types" series of the over-time plot grouped by asset type, which weighed the archive total against the weekly asset-type breakdown only after binning and so reported the days around each month and year boundary as undetermined bytes. The series is now left out entirely when every byte is accounted for. ([#248](https://github.com/dandi/usage-page/pull/248))
+- Fixed the "Undetermined file types" series of the over-time plot grouped by asset type, which weighed the archive total against the weekly asset-type breakdown only after binning and so reported the days around each month and year boundary as undetermined bytes. The series is now left out entirely when every byte is accounted for. ([#249](https://github.com/dandi/usage-page/pull/249))
 
 #### 🚀 Enhancement
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Upcoming
 
+#### 🐛 Bug Fix
+
+- Fixed the "Undetermined file types" series of the over-time plot grouped by asset type, which weighed the archive total against the weekly asset-type breakdown only after binning and so reported the days around each month and year boundary as undetermined bytes. The series is now left out entirely when every byte is accounted for. ([#248](https://github.com/dandi/usage-page/pull/248))
+
 #### 🚀 Enhancement
 
 - Dropped the "DANDI:" prefix from the hover text of the over-time plot grouped by Dandisets, so each hover leads with the Dandiset's ID and title. ([#247](https://github.com/dandi/usage-page/pull/247))

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "access-page",
-  "version": "1.11.5",
+  "version": "1.11.6",
   "description": "Visualizations of data usage across the archive.",
   "private": true,
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "access-page",
-  "version": "1.11.4",
+  "version": "1.11.5",
   "description": "Visualizations of data usage across the archive.",
   "private": true,
   "type": "module",

--- a/src/plots.ts
+++ b/src/plots.ts
@@ -5,6 +5,7 @@ import {
     parse_by_day_tsv,
     parse_by_asset_type_per_week_tsv,
     aggregate_by_timebin,
+    undetermined_bytes_per_week,
     format_bytes as format_bytes_pure,
     scaled_metric,
     format_ratio,
@@ -1513,43 +1514,42 @@ function load_over_time_plot(dandiset_id: string): Promise<void> {
                     };
                 });
 
+                // Bytes per week that the asset-type breakdown accounts for
+                const total_bytes = raw_dates.map((_, i) =>
+                    asset_types.reduce((sum, type) => sum + ((series_map.get(type) ?? [])[i] || 0), 0)
+                );
+
                 // Build an "Other" series: archive total minus the sum of all asset types
                 if (archive_data) {
-                    const archive_agg = aggregate_by_timebin(archive_data.dates, archive_data.bytes, effective_aggregation);
-                    const archive_plot_data = USE_CUMULATIVE
-                        ? make_cumulative(archive_agg.bytes_sent)
-                        : archive_agg.bytes_sent;
-                    // Build per-date lookup for the sum of all asset-type series
-                    const series_by_date = new Map<string, number>();
-                    for (const series of plot_info) {
-                        (series.x as string[]).forEach((date, idx) => {
-                            series_by_date.set(date, (series_by_date.get(date) || 0) + (series.y as number[])[idx]);
+                    const undetermined_weekly = undetermined_bytes_per_week(
+                        raw_dates, total_bytes, archive_data.dates, archive_data.bytes,
+                    );
+                    // Skip the series outright when every byte is accounted for, rather
+                    // than leaving an always-empty entry in the legend
+                    if (undetermined_weekly.some((bytes) => bytes > 0)) {
+                        const agg_other = aggregate_by_timebin(raw_dates, undetermined_weekly, effective_aggregation);
+                        const other_y = USE_CUMULATIVE ? make_cumulative(agg_other.bytes_sent) : agg_other.bytes_sent;
+                        const other_human_readable = other_y.map((b) => format_bytes(b));
+                        plot_info.push({
+                            ...(USE_OT_LINE_PLOT
+                                ? {
+                                    type: "scatter", mode: "lines", line: { color: "rgba(150,150,150,0.7)" },
+                                    ...(USE_STACKED
+                                        ? { stackgroup: "one" }
+                                        : { fill: "tozeroy", fillcolor: "rgba(150,150,150,0.15)" }),
+                                }
+                                : { type: "bar", marker: { color: "rgba(150,150,150,0.7)" } }),
+                            name: "Undetermined file types",
+                            x: agg_other.dates,
+                            y: other_y,
+                            text: agg_other.dates.map((date, idx) =>
+                                `Undetermined file types<br>${bin_label_prefix[effective_aggregation]}${date}<br>${other_human_readable[idx]}`
+                            ),
+                            textposition: "none",
+                            hoverinfo: "text",
                         });
+                        all_dates_for_layout.push(...agg_other.dates);
                     }
-                    const other_y = archive_agg.dates.map((date, i) => {
-                        const asset_type_total = series_by_date.get(date) || 0;
-                        return Math.max(0, archive_plot_data[i] - asset_type_total);
-                    });
-                    const other_human_readable = other_y.map((b) => format_bytes(b));
-                    plot_info.push({
-                        ...(USE_OT_LINE_PLOT
-                            ? {
-                                type: "scatter", mode: "lines", line: { color: "rgba(150,150,150,0.7)" },
-                                ...(USE_STACKED
-                                    ? { stackgroup: "one" }
-                                    : { fill: "tozeroy", fillcolor: "rgba(150,150,150,0.15)" }),
-                            }
-                            : { type: "bar", marker: { color: "rgba(150,150,150,0.7)" } }),
-                        name: "Undetermined file types",
-                        x: archive_agg.dates,
-                        y: other_y,
-                        text: archive_agg.dates.map((date, idx) =>
-                            `Undetermined file types<br>${bin_label_prefix[effective_aggregation]}${date}<br>${other_human_readable[idx]}`
-                        ),
-                        textposition: "none",
-                        hoverinfo: "text",
-                    });
-                    all_dates_for_layout.push(...archive_agg.dates);
                 }
 
                 const unique_dates = [...new Set(all_dates_for_layout)].sort();
@@ -1571,9 +1571,6 @@ function load_over_time_plot(dandiset_id: string): Promise<void> {
                 attach_legend_tooltips(plot_element_id, ASSET_TYPE_DESCRIPTIONS);
 
                 // Table: show total bytes per time bin (sum across all asset types)
-                const total_bytes = raw_dates.map((_, i) =>
-                    asset_types.reduce((sum, type) => sum + ((series_map.get(type) ?? [])[i] || 0), 0)
-                );
                 const agg_total = aggregate_by_timebin(raw_dates, total_bytes, effective_aggregation);
                 const per_bin_titles: Record<string, string> = {
                     weekly: "Usage per week",

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -86,6 +86,32 @@ export function aggregate_by_timebin(dates: string[], bytes_sent: number[], aggr
     };
 }
 
+/**
+ * Bytes per week that an asset-type breakdown leaves unaccounted for: for each
+ * of `week_starts` (the Mondays the breakdown is reported on), the whole-archive
+ * total for that week less the `accounted_bytes` the breakdown attributes to it.
+ * Weeks the daily series says nothing about, and any week whose parts already
+ * exceed the total, contribute nothing rather than a negative remainder.
+ *
+ * The difference has to be taken here, on the breakdown's own week grid, and
+ * binned to the display aggregation only afterwards.  Differencing binned series
+ * instead would weigh a month (or year) of daily totals against whichever whole
+ * weeks happen to begin inside it, and report the days on either side of that
+ * seam as unaccounted-for bytes.
+ */
+export function undetermined_bytes_per_week(
+    week_starts: string[],
+    accounted_bytes: number[],
+    daily_dates: string[],
+    daily_bytes: number[],
+): number[] {
+    const weekly = aggregate_by_timebin(daily_dates, daily_bytes, "weekly");
+    const total_by_week = new Map(weekly.dates.map((date, i) => [date, weekly.bytes_sent[i]]));
+    return week_starts.map((week, i) =>
+        Math.max(0, (total_by_week.get(week) ?? 0) - (accounted_bytes[i] ?? 0))
+    );
+}
+
 export function format_bytes(bytes: number, decimals = 2, use_binary = false): string {
     if (bytes === 0) return "0 Bytes";
 

--- a/tests/unit/utils.test.js
+++ b/tests/unit/utils.test.js
@@ -5,6 +5,7 @@ import {
     parse_by_day_tsv,
     parse_by_asset_type_per_week_tsv,
     aggregate_by_timebin,
+    undetermined_bytes_per_week,
     format_bytes,
     bytes_unit,
     scaled_metric,
@@ -238,6 +239,57 @@ describe("aggregate_by_timebin", () => {
         const result = aggregate_by_timebin(["2024-01-01", "2024-01-07"], [10, 20], "weekly");
         const week1Idx = result.dates.indexOf("2024-01-01");
         expect(result.bytes_sent[week1Idx]).toBe(30);
+    });
+});
+
+// ── undetermined_bytes_per_week ──────────────────────────────────────────────
+
+describe("undetermined_bytes_per_week", () => {
+    // Two whole weeks of daily totals, 10 bytes a day, straddling a year boundary:
+    // Mon 2025-12-29 through Sun 2026-01-04, then Mon 2026-01-05 onwards.
+    const week_starts = ["2025-12-29", "2026-01-05"];
+    const daily_dates = [];
+    const daily_bytes = [];
+    for (const week of week_starts) {
+        for (let offset = 0; offset < 7; offset += 1) {
+            const day = new Date(week + "T00:00:00Z");
+            day.setUTCDate(day.getUTCDate() + offset);
+            daily_dates.push(day.toISOString().slice(0, 10));
+            daily_bytes.push(10);
+        }
+    }
+
+    it("returns the weekly total less the bytes the breakdown accounts for", () => {
+        expect(undetermined_bytes_per_week(week_starts, [30, 50], daily_dates, daily_bytes)).toEqual([40, 20]);
+    });
+
+    it("returns zero for every week the breakdown fully accounts for", () => {
+        expect(undetermined_bytes_per_week(week_starts, [70, 70], daily_dates, daily_bytes)).toEqual([0, 0]);
+    });
+
+    it("clamps a week whose parts exceed its total to zero", () => {
+        expect(undetermined_bytes_per_week(week_starts, [100, 70], daily_dates, daily_bytes)).toEqual([0, 0]);
+    });
+
+    it("returns zero for a week the daily series says nothing about", () => {
+        expect(undetermined_bytes_per_week(["2025-12-22", ...week_starts], [0, 70, 70], daily_dates, daily_bytes))
+            .toEqual([0, 0, 0]);
+    });
+
+    it("attributes days to the week containing them, not to the calendar bin they fall in", () => {
+        // The 2025-12-29 week runs into January, so a difference taken per month
+        // or per year would charge those days to the wrong bin; per week, the
+        // fully accounted-for breakdown leaves nothing undetermined.
+        expect(undetermined_bytes_per_week(week_starts, [70, 70], daily_dates, daily_bytes)).toEqual([0, 0]);
+        // Same daily data binned by year splits 70/70 into 30 for 2025 and 110 for 2026
+        const yearly = aggregate_by_timebin(daily_dates, daily_bytes, "yearly");
+        expect(yearly.bytes_sent).toEqual([30, 110]);
+    });
+
+    it("ignores daily dates outside the reported weeks", () => {
+        const extended_dates = [...daily_dates, "2026-01-12"];
+        const extended_bytes = [...daily_bytes, 999];
+        expect(undetermined_bytes_per_week(week_starts, [70, 70], extended_dates, extended_bytes)).toEqual([0, 0]);
     });
 });
 


### PR DESCRIPTION
## Summary

Fixed a bug in the "Undetermined file types" series of the over-time plot grouped by asset type. The series was incorrectly calculating unaccounted bytes by comparing the archive total against the asset-type breakdown after both had been binned to the display aggregation (monthly or yearly). This caused days around month and year boundaries to be incorrectly reported as undetermined bytes.

## Changes

- **Extracted `undetermined_bytes_per_week()` function** in `src/utils.ts`: This new utility function calculates unaccounted bytes on the breakdown's native weekly grid before any aggregation. It takes the weekly totals from the daily archive data and subtracts the accounted bytes for each week, clamping negative values to zero.

- **Refactored the "Other" series calculation** in `src/plots.ts`: Instead of computing the difference after binning, the code now calls `undetermined_bytes_per_week()` to get weekly undetermined bytes, then aggregates those to the display timebin. This ensures the calculation respects week boundaries rather than calendar boundaries.

- **Added conditional rendering**: The "Undetermined file types" series is now omitted from the plot entirely when every byte is accounted for, rather than leaving an empty entry in the legend.

- **Added comprehensive test coverage** in `tests/unit/utils.test.js`: Tests verify correct calculation of undetermined bytes, handling of edge cases (fully accounted weeks, weeks with no data, weeks exceeding totals), and proper attribution of days to weeks across calendar boundaries.

## Implementation Details

The key insight is that the difference between archive totals and asset-type breakdown must be taken on the breakdown's own week grid. Taking the difference after binning to months or years would incorrectly charge days on either side of those calendar seams as unaccounted bytes, even though they're fully accounted for within their respective weeks.

https://claude.ai/code/session_011WQSBNp73KqgUkEmwdYxaw