### PR TITLE
Removed gap left by invisible section anchor link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 #### 🚀 Enhancement
 
+- Removed the gap to the left of the "View:" label above each plot, left there by the section anchor link that is invisible until the controls are hovered. ([#250](https://github.com/dandi/usage-page/pull/250))
 - Dropped the "DANDI:" prefix from the hover text of the over-time plot grouped by Dandisets, so each hover leads with the Dandiset's ID and title. ([#247](https://github.com/dandi/usage-page/pull/247))
 - Replaced the totals sentence and its block of footnotes above the plots with a table of the same metrics, each caveat behind an info icon on the metric (or the caption) it qualifies. The metrics are read as a row of labelled columns that wraps over as many lines as a narrow viewport needs, so the summary is never scrolled sideways. ([#246](https://github.com/dandi/usage-page/pull/246))
 - Restyled the scroll bars of every table view as a slim, rounded, accent-tinted thumb on a transparent track, replacing the platform default that read as a light gray slab against the table, most jarringly in dark mode. ([#245](https://github.com/dandi/usage-page/pull/245))

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "access-page",
-  "version": "1.11.6",
+  "version": "1.11.7",
   "description": "Visualizations of data usage across the archive.",
   "private": true,
   "type": "module",

--- a/src/styles.css
+++ b/src/styles.css
@@ -266,6 +266,7 @@ h1 {
 }
 
 .ControllerContainer {
+    position: relative;
     display: flex;
     align-items: center;
     justify-content: center;
@@ -379,14 +380,20 @@ input[type="number"]:focus {
     scroll-margin-top: 60px;
 }
 
-/* ── Per-plot anchor link ── */
+/* ── Per-plot anchor link ──
+   Taken out of the flex flow and tucked into the container's left padding so
+   the anchor, which is invisible until the container is hovered, leaves no
+   gap to the left of the first control (the "View:" label). */
 .section-anchor {
+    position: absolute;
+    left: 6px;
+    top: 50%;
+    transform: translateY(-50%);
     color: var(--color-text-secondary);
     text-decoration: none;
     font-size: 1em;
     font-weight: 400;
     line-height: 1;
-    padding: 0 4px;
     opacity: 0;
     transition: opacity 0.15s, color 0.15s;
     user-select: none;


### PR DESCRIPTION
## Summary
Repositioned the per-plot section anchor link from the flex flow to an absolute position within its container, eliminating the unwanted gap that appeared to the left of the "View:" label.

## Changes
- Made `.ControllerContainer` a positioning context by adding `position: relative`
- Converted `.section-anchor` from an inline element to absolutely positioned:
  - Positioned at `left: 6px` and vertically centered with `top: 50%` and `transform: translateY(-50%)`
  - Removed the `padding: 0 4px` that was creating the gap
- Updated the comment to explain the positioning rationale

## Implementation Details
The section anchor link is invisible until the user hovers over the controls. Previously, it occupied space in the flex layout even when hidden, creating a visible gap. By taking it out of the flex flow and positioning it absolutely within the container, the anchor no longer affects the layout of the "View:" label and other controls while remaining accessible on hover.

https://claude.ai/code/session_01FnUDb73QJtjoyBd3VAxL8P